### PR TITLE
fix: stretched image

### DIFF
--- a/assets/sass/_layout.scss
+++ b/assets/sass/_layout.scss
@@ -19,6 +19,7 @@
     -webkit-animation: 0.5s ease-in forwards fadein;
     animation: 0.5s ease-in forwards fadein;
     opacity: 1;
+    object-fit: cover;
   }
 
   .author-name {


### PR DESCRIPTION
Hi,

This small PR fixing the stretched image.

Solution:
Adding `object-fit: cover;` on `.author-avatar` class seems fix it.

Before adding `object-fit` class:
![Before](https://i.imgur.com/0Doz0Kd.png)

As you can see the image is stretched out.

After adding `object-fit` class:
![After](https://i.imgur.com/ldaa4Ac.png)

The husky image size used above is : 900x500 pixel