### PR TITLE
Fix template failure in bio.html when avatar cannot be found

### DIFF
--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -1,9 +1,9 @@
 {{ $avatar_img := .Site.Params.author.avatar }}
 {{ $avatar_img_alt := .Site.Params.author.name }}
 {{ $image := resources.Get $avatar_img }}
-{{ $image := $image.Fill "100x100 webp" }}
 <div class="author">
     {{ with $image }}
+    {{ $image := $image.Fill "100x100 webp" }}
     <img class="author-avatar" 
     src="{{ $image.RelPermalink }}" 
     alt="{{ $avatar_img_alt }}" width="{{ .Width }}" height="{{ .Height }}" />


### PR DESCRIPTION
## What problem does this PR solve?
Template error when params.author.avatar cannot be found.

Full error:
```
Start building sites … 
hugo v0.92.2+extended linux/amd64 BuildDate=2023-01-31T11:11:57Z VendorInfo=ubuntu:0.92.2-1ubuntu0.1  
Error: Error building site: failed to render pages: render of "home" failed: execute of template failed: template:   
index.html:8:15: executing "index.html" at <partial "bio" .>: error calling partial: "/home/mike/git/testblog  
/themes/hugo-blog-awesome/layouts/partials/bio.html:4:19": execute of template failed: template: partials/bio.html:4:19:   
executing "partials/bio.html" at <$image.Fill>: nil pointer evaluating resource.Resource.Fill  
Built in 17 ms
```

## Is this PR adding a new feature?
No

## Is this PR related to any issue or discussion?
No, hope that's ok. It's quicker to make a PR than opening up an issue.

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).