### PR TITLE
Use dateFormat hugo function to support localization

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,9 @@
 title = "Awesome Hugo blog"
 baseURL = 'https://hugo-blog-awesome.netlify.app/'
+
+# This is what goes in <html lang="">
 languageCode = 'en-us'
+
 theme = "hugo-blog-awesome"
 
 # This defines how dates are formatted

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,7 +4,7 @@ languageCode = 'en-us'
 theme = "hugo-blog-awesome"
 
 # This defines how dates are formatted
-defaultContentLanguage = "en"
+defaultContentLanguage = "en-gb"
 
 # To enable Google Analytics 4 (gtag.js) provide G-MEASUREMENT_ID below.
 # To disable  Google Analytics, simply leave the field empty or remove the next line

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,9 @@ baseURL = 'https://hugo-blog-awesome.netlify.app/'
 languageCode = 'en-us'
 theme = "hugo-blog-awesome"
 
+# This defines how dates are formatted
+defaultContentLanguage = "en"
+
 # To enable Google Analytics 4 (gtag.js) provide G-MEASUREMENT_ID below.
 # To disable  Google Analytics, simply leave the field empty or remove the next line
 googleAnalytics = '' # G-MEASUREMENT_ID

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,9 +4,9 @@
         <article>
             <header class="header">
                 <h1 class="header-title">{{ .Title }}</h1>
-                {{ $ISO_time := .Date.Format "2006-01-02T15:04:05-07:00" }}
+                {{ $ISO_time := dateFormat "2006-01-02T15:04:05-07:00" .Date }}
                 <div class="post-meta">
-                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ .Date.Format "Jan 2, 2006" }} </time>
+                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ dateFormat "Jan 2, 2006" .Date }} </time>
                 </div>
             </header>
             <div class="page-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
                 <h1 class="header-title">{{ .Title }}</h1>
                 {{ $ISO_time := dateFormat "2006-01-02T15:04:05-07:00" .Date }}
                 <div class="post-meta">
-                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ dateFormat "Jan 2, 2006" .Date }} </time>
+                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ .Date | time.Format ":date_medium" }} </time>
                 </div>
             </header>
             <div class="page-content">

--- a/layouts/partials/meta/post.html
+++ b/layouts/partials/meta/post.html
@@ -1,6 +1,6 @@
 {{/*  These meta tags are rendered only in the posts section (i.e. in single/list page)  */}}
 {{ if eq .Section "posts" }}
-    {{ $ISO_date := .Date.Format "2006-01-02T15:04:05Z0700" | safeHTML }}
+    {{ $ISO_date := dateFormat "2006-01-02T15:04:05Z0700" .Date | safeHTML }}
     <!-- Pagination meta tags for list pages only -->
     {{ $paginator := .Paginate (where .Pages "Section" "blog") }}
     {{ if $paginator }}
@@ -38,11 +38,11 @@
         "@type": "Person",
         "name": "{{ .Site.Params.github }}"
         },
-        "datePublished": "{{ .Date.Format "2006-01-02" }}",
+        "datePublished": "{{ dateFormat "2006-01-02" .Date }}",
         "description": {{ .Description }},
         "wordCount": {{ .WordCount }},
         "mainEntityOfPage": "True",
-        "dateModified": "{{ .Lastmod.Format "2006-01-02" }}",
+        "dateModified": "{{ dateFormat "2006-01-02" .Lastmod }}",
         "image": {
         "@type": "imageObject",
         "url": "{{ with .Params.image }}{{ .Permalink }}{{ end }}"

--- a/layouts/partials/postCard.html
+++ b/layouts/partials/postCard.html
@@ -5,6 +5,6 @@
     {{/*  format date string to create an ISO 8601 string  */}}
     {{ $ISO_date := "2006-01-02T15:04:05Z0700" }}
     <time class="post-item-meta" datetime="{{ dateFormat $ISO_date .Date }}">
-        {{ dateFormat "02 Jan 2006" .Date }}
+        {{ .Date | time.Format ":date_medium" }}
     </time>
 </article>

--- a/layouts/partials/postCard.html
+++ b/layouts/partials/postCard.html
@@ -5,6 +5,6 @@
     {{/*  format date string to create an ISO 8601 string  */}}
     {{ $ISO_date := "2006-01-02T15:04:05Z0700" }}
     <time class="post-item-meta" datetime="{{ .Date.Format $ISO_date }}">
-        {{ .Date.Format "02 Jan 2006" }}
+        {{ dateFormat "02 Jan 2006" .Date }}
     </time>
 </article>

--- a/layouts/partials/postCard.html
+++ b/layouts/partials/postCard.html
@@ -4,7 +4,7 @@
     </h4>
     {{/*  format date string to create an ISO 8601 string  */}}
     {{ $ISO_date := "2006-01-02T15:04:05Z0700" }}
-    <time class="post-item-meta" datetime="{{ .Date.Format $ISO_date }}">
+    <time class="post-item-meta" datetime="{{ dateFormat $ISO_date .Date }}">
         {{ dateFormat "02 Jan 2006" .Date }}
     </time>
 </article>


### PR DESCRIPTION
https://gohugo.io/functions/dateformat/

## What problem does this PR solve?

Dates are not formatted according the the language locale specified in config.toml. It sticks to English.

## Is this PR adding a new feature?

Sort of: now people can choose to display dates according to the language they want (`defaultContentLanguage` config).

## Is this PR related to any issue or discussion?

Nope

## PR Checklist

- [x] I have verified that the code works as described/as intended.
  - ~~It does, but I didn't find a way to format dates UK style, only US style 😕  (15 Feb 2022 vs. Feb 15, 2022)~~ fixed in config
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).