### PR TITLE
Add baseURL variable on See all posts button

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,9 @@
             {{ end }}
             {{ if gt (len $posts) 5 }}
             <p>
-                <a href="{{ .Site.Home.Permalink }}posts/">See all posts</a>
+                {{ range $firstSection := (where .Site.Sections "Section" "in" (first 1 (.Site.Params.mainSections))) }}
+                <a href="{{ $firstSection.Permalink }}">See all posts</a>
+                {{ end }}
             </p>
             {{ end }}
         </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
             {{ end }}
             {{ if gt (len $posts) 5 }}
             <p>
-                <a href="{{ .Site.Home.Permalink }}/posts/">See all posts</a>
+                <a href="{{ .Site.Home.Permalink }}posts/">See all posts</a>
             </p>
             {{ end }}
         </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
             {{ end }}
             {{ if gt (len $posts) 5 }}
             <p>
-                <a href="/posts/">See all posts</a>
+                <a href="{{ .Site.Home.Permalink }}/posts/">See all posts</a>
             </p>
             {{ end }}
         </main>


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?


P : Fix for 404 errors in see all posts if the default URL is not root.  
S : Add a baseURL variable to the link in the button.  


## Is this PR adding a new feature?


no


## Is this PR related to any issue or discussion?


[ Issue #36 (closed) ](https://github.com/hugo-sid/hugo-blog-awesome/issues/36)



## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
