### PR TITLE
feat: add comments partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ To create a new post, run the following command:
 
 Then, edit the `my-first-post.md` file to suit your needs.
 
+### Comments
+
+To enable Disqus comments, set `disqusShortname` in your site's `config.toml`.
+
+To use another comments system, provide your own `comments.html` partial in `layouts\partials\comments.html`.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](https://github.com/hugo-sid/hugo-blog-awesome/blob/main/CONTRIBUTING.md).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,12 +10,15 @@ theme = "hugo-blog-awesome"
 defaultContentLanguage = "en-gb"
 
 # To enable Google Analytics 4 (gtag.js) provide G-MEASUREMENT_ID below.
-# To disable  Google Analytics, simply leave the field empty or remove the next line
+# To disable Google Analytics, simply leave the field empty or remove the next line
 googleAnalytics = '' # G-MEASUREMENT_ID
-
 
 # Enable emojis globally
 enableEmoji = true
+
+# To enable Disqus comments, provide Disqus Shortname below.
+# To disable Disqus comments, simply leave the field empty or remove the next line
+disqusShortname = ''
 
 # set markup.highlight.noClasses=false to enable code highlight
 [markup]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,6 +19,7 @@
                 {{ .Content }}
             </div>
         </article>
+        {{- partial "comments.html" . -}}
     </main>
 </div>
 {{ end }}

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,4 @@
+{{- if .Site.DisqusShortname -}}
+<hr style="margin-top: 40px; margin-bottom: 40px;" />
+{{ template "_internal/disqus.html" . }}
+{{- end -}}


### PR DESCRIPTION
## What problem does this PR solve?

Lack of support for a comments section at the bottom of posts.

## Is this PR adding a new feature?

Introduces a `comments.html` partial that is included at the bottom of `single.html` and defaults to using the builtin Disqus template if `.Site.DisqusShortname` is set.

## Is this PR related to any issue or discussion?

Closes #32

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
