### PR TITLE
fix: resolve theme toggle race condition

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -46,32 +46,30 @@
     // init theme ASAP, then do the rest.
     initTheme(getThemeState());
     requestAnimationFrame(() => body.classList.remove("notransition"))
-    setTimeout(() => {
-        const toggleTheme = () => {
-            const state = getThemeState();
-            if (state === THEMES.DARK) {
-                localStorage.setItem(LS_THEME_KEY, THEMES.LIGHT);
-                initTheme(THEMES.LIGHT);
-            } else if (state === THEMES.LIGHT) {
-                localStorage.setItem(LS_THEME_KEY, THEMES.DARK);
-                initTheme(THEMES.DARK);
-            }
-        };
+    const toggleTheme = () => {
+        const state = getThemeState();
+        if (state === THEMES.DARK) {
+            localStorage.setItem(LS_THEME_KEY, THEMES.LIGHT);
+            initTheme(THEMES.LIGHT);
+        } else if (state === THEMES.LIGHT) {
+            localStorage.setItem(LS_THEME_KEY, THEMES.DARK);
+            initTheme(THEMES.DARK);
+        }
+    };
 
-        window.addEventListener("DOMContentLoaded", () => {
-            // Theme switch
-            const lamp = document.getElementById("mode");
+    window.addEventListener("DOMContentLoaded", () => {
+        // Theme switch
+        const lamp = document.getElementById("mode");
 
-            lamp.addEventListener("click", () => toggleTheme());
+        lamp.addEventListener("click", () => toggleTheme());
 
-            // Blur the content when the menu is open
-            const cbox = document.getElementById("menu-trigger");
+        // Blur the content when the menu is open
+        const cbox = document.getElementById("menu-trigger");
 
-            cbox.addEventListener("change", function () {
-                const area = document.querySelector(".wrapper");
-                if (this.checked) return area.classList.add("blurry");
-                area.classList.remove("blurry");
-            });
+        cbox.addEventListener("change", function () {
+            const area = document.querySelector(".wrapper");
+            if (this.checked) return area.classList.add("blurry");
+            area.classList.remove("blurry");
         });
-    }, 0)
+    });
 })();


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->

## What problem does this PR solve?

On Firefox, the theme toggle does not work for me, even on the example site. I believe this is because the event listeners are attached inside of a `setTimeout` call (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#deferral_of_timeouts_during_pageload)):

> Firefox will defer firing setTimeout() timers while the current tab is loading. Firing is deferred until the main thread is deemed idle (similar to [window.requestIdleCallback()](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)), or until the load event is fired.

The call to `window.addEventListener('DOMContentLoaded', ...)` therefore happens _after_ the DOM has already loaded, so the event is missed and the theme toggle event listeners are not attached.

This PR just removes the `setTimeout` wrapping the event listeners, which resolves the issue for me.

## Is this PR adding a new feature?

No.

## Is this PR related to any issue or discussion?

No.

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).

By the way, thanks for your theme, it's great!
