### PR TITLE
Move tableOfContents sectin to correct part of config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,10 @@ disqusShortname = ''
     noClasses = false
   [markup.goldmark.renderer]
     unsafe = true
+	[markup.tableOfContents]
+		startLevel = 2 # ToC starts from H2
+		endLevel = 4 # ToC ends at H4
+		ordered = false # generates <ul> instead of <ol>
 
 [menu]
   [[menu.main]]
@@ -94,9 +98,4 @@ url = "https://twitter.com"
 [[params.socialIcons]]
 name = "Rss"
 url = "index.xml"
-
-[tableOfContents]
-startLevel = 2 # ToC starts from H2
-endLevel = 4 # ToC ends at H4
-ordered = false # generates <ul> instead of <ol>
 


### PR DESCRIPTION
According to
https://gohugo.io/getting-started/configuration-markup/#table-of-contents, the "tableOfContents" section in the config file needs to be within the "markup" section, which I've tested and confirmed to be correct.

## What problem does this PR solve?

Config bug where tableOfContents is in the wrong section

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
