### PR TITLE
fix: make specifying date optional

### DIFF
--- a/exampleSite/content/pages/about.md
+++ b/exampleSite/content/pages/about.md
@@ -1,7 +1,6 @@
 ---
 title: About
 description: 'Hugo, the world''s fastest framework for building websites'
-date: '2019-02-28'
 author: Hugo Authors
 ---
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,10 +4,12 @@
         <article>
             <header class="header">
                 <h1 class="header-title">{{ .Title }}</h1>
-                {{ $ISO_time := dateFormat "2006-01-02T15:04:05-07:00" .Date }}
+                {{ with .Date }}
+                {{ $ISO_time := dateFormat "2006-01-02T15:04:05-07:00" . }}
                 <div class="post-meta">
-                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ .Date | time.Format ":date_medium" }} </time>
+                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ . | time.Format ":date_medium" }} </time>
                 </div>
+                {{ end }}
             </header>
             {{- if or .Params.toc .Site.Params.toc }}
             <details class="toc">


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Make specifying date optional. This is useful for standalone pages like about page.

## Is this PR adding a new feature?

<!--
A small description of the feature.
-->

## Is this PR related to any issue or discussion?

https://github.com/hugo-sid/hugo-blog-awesome/discussions/78


## PR Checklist

- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [ ] This change **does not** include any external library/resources.
- [ ] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
