### PR TITLE
Fix enforced defaultColor

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,18 @@
 <!DOCTYPE html>
+{{- $defaultColor := .Site.Params.defaultColor | default "auto" -}}
+
+{{/* allow website developer to enforce default dark mode */}}
+{{- if eq $defaultColor "dark" -}}
+<html lang="{{ .Site.LanguageCode }}" class="dark">
+{{- else if eq $defaultColor "light" -}}
+<html lang="{{ .Site.LanguageCode }}" class="light">
+{{- else -}}
 <html lang="{{ .Site.LanguageCode }}">
+{{- end -}}
+
 {{- partial "head.html" . -}}
 
-<body data-theme="{{ .Site.Params.defaultColor | default "auto" }}" class="notransition">
+<body data-theme="{{ $defaultColor }}" class="notransition">
     {{- partial "scriptsBodyStart.html" . -}}
     {{- partial "header.html" . -}}
     <div class="wrapper">


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?
should solve #50 
and allow to enforce default theme to dark by site developer in no-script browsers.
<!--
A small description of the fix.
-->

## Is this PR adding a new feature?
no
<!--
A small description of the feature.
-->

## Is this PR related to any issue or discussion?
issue #50 
<!--
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
