### PR TITLE
Update _miscellaneous.scss - fadein keyframe

### DIFF
--- a/assets/sass/_miscellaneous.scss
+++ b/assets/sass/_miscellaneous.scss
@@ -5,7 +5,7 @@
     }
 
     100% {
-        opacity: 0.8;
+        opacity: 1;
     }
 }
 


### PR DESCRIPTION
fadein keyframe had value 0.8 instead of 1 for opacity 100%.

<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?
Opacity Issue
<!--
A small description of the fix.
-->
The Opacity was 0.8 instead of 1
## Is this PR adding a new feature?
No
<!--
A small description of the feature.
-->
Image 100% opacity
## Is this PR related to any issue or discussion?
<!--
No
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->
No

## PR Checklist

- [X ] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [X ] This change **does not** include any external library/resources.
- [ X] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [ X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
