### PR TITLE
Fixed bug for bold titles in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,7 +15,7 @@
                 {{ $currentPage := . }}
                 {{ range .Site.Menus.main }}
                 <li>
-                    <a class="menu-link {{ if or ($currentPage.IsMenuCurrent " main" .)
+                    <a class="menu-link {{ if or ($currentPage.IsMenuCurrent "main" .)
                         ($currentPage.HasMenuCurrent "main" .) }}active{{ end }}" href="{{ .URL }}">
                         {{ .Name }}
                     </a>
@@ -23,7 +23,7 @@
                     <ul>
                         {{ range .Children }}
                         <li>
-                            <a class="menu-link {{ if $currentPage.IsMenuCurrent " main" . }}active{{ end }}"
+                            <a class="menu-link {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}"
                                 href="{{ .URL }}">
                                 {{ .Name }}
                             </a>


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

<!--
A small description of the fix.
-->

The header page titles (top right) are supposed to be bold when we are at that page. For example, "Posts" is supposed to be bold when we are in www.domain/posts, and it currently is not. A couple of typos are the cause.

## Is this PR adding a new feature?

<!--
A small description of the feature.
-->
No.

## Is this PR related to any issue or discussion?

<!--
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->
Not reported as far as I am concerned.


## PR Checklist

- [ x] I have verified that the code works as described/as intended.
- [ x] This change adds a social icon which has a permissive license to use it.
- [ x] This change **does not** include any external library/resources.
- [ x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [ x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
