### PR TITLE
ci: pin third-party GitHub actions by hash

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update PRs with conflict labels
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # releases/2.1.0
         with:
           dirtyLabel: "conflicts"
           #removeOnDirtyLabel: "PR: ready to ship"
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@54ef36785e9f4cb5ecf1949cfc9b00dbb621d761 # v1.8.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Use pinned dependencies for GitHub action. Pinned dependencies reduce security risks.

## Is this PR adding a new feature?

No.

## Is this PR related to any issue or discussion?

No.


## PR Checklist

- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [ ] This change **does not** include any external library/resources.
- [ ] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
