### PR TITLE
fix: hugo error when dateFormat parameter is not set

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -73,7 +73,7 @@ disqusShortname = ''
   # Your custom scripts will be concatinated to one file `custom.js`.
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
-  dateFormat = "January 2, 2006" # default date format used on various pages
+  dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .

--- a/layouts/partials/postCard.html
+++ b/layouts/partials/postCard.html
@@ -4,7 +4,7 @@
     </h4>
     {{/* format date string to create an ISO 8601 string */}}
     {{ $ISO_date := "2006-01-02T15:04:05Z0700" }}
-    {{ $configDateFormat := .Site.Params.dateFormat }}
+    {{ $configDateFormat := .Site.Params.dateFormat | default "2 Jan 2006" }}
     <time class="post-item-meta" datetime="{{ dateFormat $ISO_date .Date }}">
         {{ time.Format $configDateFormat .Date }}
         {{/* OLD FORMAT: .Date.Format $configDateFormat */}}


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Fixes hugo error when `dateFormat` parameter is not set.

## Is this PR adding a new feature?

No.

## Is this PR related to any issue or discussion?

https://github.com/hugo-sid/hugo-blog-awesome/issues/128


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
