### PR TITLE
Fix: Language Selector accessibility

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -39,7 +39,7 @@
                 <!-- Language List -->
                 {{ if .IsTranslated }}
                     <li>
-                        <select class="lang-list" id="select-language" onchange="location = this.value;">
+                        <select aria-label="Select Language" class="lang-list" id="select-language" onchange="location = this.value;">
                             {{ $siteLanguages := .Site.Languages}}
                             {{ $pageLang := .Page.Lang}}
                             {{ range .Page.AllTranslations }}


### PR DESCRIPTION
Fix: Accesibility rules, regains 100% accesibility score, read more: https://dequeuniversity.com/rules/axe/4.7/select-name

<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Fixes the accessibility parameter on the `select` for language selector

## Is this PR adding a new feature? No

Fixes the accessibility paramterer on the `select` for language selector, thus regaining 100% accessibility score on PagesInsight for desktop, follows the rules laid by: https://dequeuniversity.com/rules/axe/4.7/select-name and adds an `aria-label=""` so it doesn't add extra text on the page itself.


## Is this PR related to any issue or discussion? No

<!--
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->


## PR Checklist

- [ x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x ] This change **does not** include any external library/resources.
- [ x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [ x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
