### PR TITLE
ci: update GitHub access token for release please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,6 @@
         - uses: google-github-actions/release-please-action@ca6063f4ed81b55db15b8c42d1b6f7925866342d # v3.7.11
           with:
             release-type: simple
-            token: ${{ secrets.GH_PAT }}
+            token: ${{ secrets.HBA_RELEASE_PLEASE_TOKEN }}
             pull-request-header: ":rocket: New release"
             changelog-types: '[{"type":"feat","section":":sparkles: Features","hidden":false},{"type":"fix","section":":bug: Bug Fixes","hidden":false},{"type":"chore","section":":hammer: Housekeeping","hidden":false},{"type":"docs","section":":memo: Documentation","hidden":false},{"type":"ci","section":":construction_worker: CI/CD","hidden":false},{"type":"perf","section":":zap: Performance","hidden":false},{"type":"refactor","section":":recycle: Refactoring","hidden":false},{"type":"style","section":":art: Style","hidden":false},{"type":"test","section":":white_check_mark: Tests","hidden":false}]'


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Rename and regenerate the expiring GitHub action token.

## Is this PR adding a new feature?

No.

## Is this PR related to any issue or discussion?

No.


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
