### PR TITLE
Add parameter to open ToC

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -67,6 +67,7 @@ disqusShortname = ''
   description = "Minimal Hugo blog theme with light and dark mode support"
   mainSections = ['posts']
   toc = true # set to false to disable table of contents 'globally'
+  tocOpen = false # set to true to open table of contents by default
   goToTop = true # set to false to disable 'go to top' button
   additionalScripts = ['js/custom.js', 'js/custom-2.js']
   # Will try to load 'assets/js/custom.js' and 'assets/js/custom-2.js'.
@@ -130,6 +131,7 @@ disqusShortname = ''
   description = "Un tema Hugo veloce e minimalista con supporto per la modalità chiara e scura, per la gestione di un sito o di un blog personale"
   mainSections = ['posts']
   toc = true # set to false to disable table of contents 'globally'
+  tocOpen = false # set to true to open table of contents by default
   goToTop = true # set to false to disable 'go to top' button
   additionalScripts = ['js/custom.js', 'js/custom-2.js']
   # Will try to load 'assets/js/custom.js' and 'assets/js/custom-2.js'.

--- a/exampleSite/content/en/posts/table-of-content/index.md
+++ b/exampleSite/content/en/posts/table-of-content/index.md
@@ -39,3 +39,22 @@ To disable ToC on certain posts, you have to follow two steps.
     toc: false
     ---
     ```
+
+## Open table of content
+
+By default, ToC is closed. To open it by default, set parameter `tocOpen` to `true` in `config.toml`.
+
+```toml
+[params]
+  tocOpen = true
+```
+
+Or simply add the `tocOpen` parameter to the front matter of the post.
+
+```yaml
+---
+title: How to enable table of content
+date: 2023-05-02
+tocOpen: true
+---
+```

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,13 @@
             </header>
             {{- if .Site.Params.toc -}}
                 {{ if not (eq .Params.toc false) }}
-                <details class="toc">
+                {{ $tocOpen := "" }}
+                {{ if or .Site.Params.tocOpen .Params.tocOpen }}
+                    {{ if not (eq .Params.tocOpen false) }}
+                        {{ $tocOpen = "open" }}
+                    {{ end }}
+                {{ end }}
+                <details class="toc" {{ $tocOpen }}>
                     <summary><b>{{ T "single.table_of_contents" }}</b></summary>
                     {{ .TableOfContents }}
                 </details>


### PR DESCRIPTION
## What problem does this PR solve?

This PR addresses a requirement for my blog where I wanted to make the Table of Contents (ToC) visible to all users across all sections of each blog post. Currently, to achieve this, I had to override the `layouts/_default/single.html` file to open the ToC. This seemed like a functionality that could be supported by this template, so I've decided to try it.

As demonstrated in [this commit of my blog](https://github.com/cruizba/cruizba.dev/commit/7c3aa364cbc1f0283b781be14c4fb2d0474141c7), adding the `open` attribute to the `<details>` tag required overriding the entire HTML file.

## Is this PR adding a new feature?

This PR introduces a `tocOpen` parameter to control the visibility of the ToC. This new parameter doesn't alter any existing default configurations or behaviors. It simply provides an option to open the ToC either globally or on a per-post basis.

The behavior is as follows:

| Global `tocOpen` | Post `tocOpen` | Is ToC Open |
|---|---|---|
| `true` | `true` | Yes |
| `true` | `false` | Yes, unless the `tocOpen` parameter is explicitly defined as `false` in the Post front matter. If undefined, it will be visible. |
| `false` | `true` | Yes |
| `false` | `false` | No (Default behavior) |

I've documented the usage in the example site:

https://github.com/hugo-sid/hugo-blog-awesome/pull/138/commits/1a11d5c2ca17e82b103a2f95fb9811fd8f8329f0#diff-991e446141b7b5aa3082f010cae332351b7a95673fccaec1f97cc3f5ae3d2f28

## Is this PR related to any issue or discussion?

I did not see anything related.


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
