### PR TITLE
Fix disqus deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .hugo_build.lock
+.hvm
+exampleSite/public/
 exampleSite/resources/
 exampleSite/.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Then, edit the `my-first-post.md` file to suit your needs.
 
 ### Comments
 
-To enable Disqus comments, set `disqusShortname` in your site's `config.toml`.
+To enable Disqus comments, set `services.disqus.shortname` in your site's `hugo.toml`.
 
 To use another comments system, provide your own `comments.html` partial in `layouts\partials\comments.html`.
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -9,17 +9,20 @@ theme = "hugo-blog-awesome"
 # This defines how dates are formatted
 defaultContentLanguage = "en-gb"
 
-# To enable Google Analytics 4 (gtag.js) provide G-MEASUREMENT_ID below.
-# To disable Google Analytics, simply leave the field empty or remove the next line
-googleAnalytics = '' # G-MEASUREMENT_ID
-
 # Enable emojis globally
 enableEmoji = true
 ignoreErrors = ["additional-script-loading-error"] # ignore error of loading additional scripts.
 
+[services]
+# To enable Google Analytics 4 (gtag.js) provide G-MEASUREMENT_ID below.
+# To disable Google Analytics, simply leave the field empty or remove the next two lines
+  [services.googleAnalytics]
+    id = '' # G-MEASUREMENT_ID
+
 # To enable Disqus comments, provide Disqus Shortname below.
-# To disable Disqus comments, simply leave the field empty or remove the next line
-disqusShortname = ''
+# To disable Disqus comments, simply leave the field empty or remove the next two lines
+  [services.disqus]
+    shortname = ''
 
 # set markup.highlight.noClasses=false to enable code highlight
 [markup]

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,4 +1,4 @@
-{{- if .Site.DisqusShortname -}}
+{{- if .Site.Config.Services.Disqus.Shortname -}}
 <hr style="margin-top: 40px; margin-bottom: 40px;" />
 {{ template "_internal/disqus.html" . }}
 {{- end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
 
 [build.environment]
-  HUGO_VERSION = "0.116.1"
+  HUGO_VERSION = "0.122.0"
   HUGO_THEME = "repo"
 
 # Deploy Preview context: all deploys generated from


### PR DESCRIPTION
## What problem does this PR solve?

Currently, when running hugo preview for the example site, a deprecation warning is emitted:

```
hugo --logLevel info --themesDir ../.. | grep deprecated
INFO  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```

This PR fixes the deprecation warnings concerning the disqus comment system.

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).

This PR also corrects the documentation for disqus comment system and for use of google analytics.