### PR TITLE
Bump KaTeX to latest version 0.16.9

### DIFF
--- a/exampleSite/content/de/posts/math-typesetting/index.md
+++ b/exampleSite/content/de/posts/math-typesetting/index.md
@@ -15,12 +15,12 @@ In this example we will be using [KaTeX](https://katex.org/).
 
 - To enable KaTeX globally, set the parameter `math` to `true` in a project's
   configuration file as follows.
-  - `config.toml`
+  - `hugo.toml`
     ```toml
     [params]
       math = true
     ```
-  - `config.yaml`
+  - `hugo.yaml`
     ```yaml
     params:
       math: true

--- a/exampleSite/content/en/posts/math-typesetting/index.md
+++ b/exampleSite/content/en/posts/math-typesetting/index.md
@@ -15,12 +15,12 @@ In this example we will be using [KaTeX](https://katex.org/).
 
 - To enable KaTeX globally, set the parameter `math` to `true` in a project's
   configuration file as follows.
-  - `config.toml`
+  - `hugo.toml`
     ```toml
     [params]
       math = true
     ```
-  - `config.yaml`
+  - `hugo.yaml`
     ```yaml
     params:
       math: true

--- a/exampleSite/content/it/posts/math-typesetting/index.md
+++ b/exampleSite/content/it/posts/math-typesetting/index.md
@@ -15,12 +15,12 @@ In questo esempio utilizzeremo [KaTeX](https://katex.org/).
 
 - Per abilitare KaTeX a livello globale, impostate il parametro `math` a `true` nella configurazione di un progretto come segue.
 
-  - `config.toml`
+  - `hugo.toml`
     ```toml
     [params]
       math = true
     ```
-  - `config.yaml`
+  - `hugo.yaml`
     ```yaml
     params:
       math: true

--- a/exampleSite/content/ru/posts/math-typesetting/index.md
+++ b/exampleSite/content/ru/posts/math-typesetting/index.md
@@ -14,12 +14,12 @@ math: true
 В этом примере, мы будем использовать [KaTeX](https://katex.org/).
 
 - Для включения KaTeX глобально, установите параметр `math` в `true` в конфигурационный файл проекта в формате, который вы используете.
-  - `config.toml`
+  - `hugo.toml`
     ```toml
     [params]
       math = true
     ```
-  - `config.yaml`
+  - `hugo.yaml`
     ```yaml
     params:
       math: true

--- a/layouts/partials/helpers/katex.html
+++ b/layouts/partials/helpers/katex.html
@@ -1,14 +1,14 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css"
-    integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+    integrity="sha512-fHwaWebuwA7NSF5Qg/af4UeDx9XqUpYpOGgubo3yWu+b2IQR4UeQwbb42Ti7gVAjNtVoI/I9TEoYeu9omwcC6g==" crossorigin="anonymous" crossorigin="anonymous" />
 
 <!-- The loading of KaTeX is deferred to speed up page rendering -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.js"
-    integrity="sha384-PwRUT/YqbnEjkZO0zZxNqcxACrXe+j766U2amXcgMg5457rve2Y7I6ZJSm2A0mS4"
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+    integrity="sha512-LQNxIMR5rXv7o+b1l8+N1EZMfhG7iFZ9HhnbJkTp4zjNr5Wvst75AqUeFDxeRUa7l5vEDyUiAip//r+EFLLCyA=="
     crossorigin="anonymous"></script>
 
 <!-- To automatically render math in text elements, include the auto-render extension: -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/contrib/auto-render.min.js"
-    integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous" onload="renderMathInElement(document.body, {
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+    integrity="sha512-iWiuBS5nt6r60fCz26Nd0Zqe0nbk1ZTIQbl3Kv7kYsX+yKMUFHzjaH2+AnM6vp2Xs+gNmaBAVWJjSmuPw76Efg==" crossorigin="anonymous" onload="renderMathInElement(document.body, {
       delimiters: [
         {left: '$$', right: '$$', display: true},
         {left: '$', right: '$', display: false}


### PR DESCRIPTION
## What problem does this PR solve?

This PR bumps KaTeX scripts to their latest version.
It also changes name of config files in the KaTeX documentation from `config.toml` to `hugo.toml`.

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
