### PR TITLE
Fixes paginator issue since hugo v0.123.0

### DIFF
--- a/exampleSite/content/de/posts/rich-content/index.md
+++ b/exampleSite/content/de/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple DesignReviewed 1085870671291310081 >}}
+{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/en/posts/rich-content/index.md
+++ b/exampleSite/content/en/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple DesignReviewed 1085870671291310081 >}}
+{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/it/posts/rich-content/index.md
+++ b/exampleSite/content/it/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo viene distribuito con alcuni [Shortcode integrati](https://gohugo.io/conten
 
 ## Semplice Shortcode Per Twitter
 
-{{< twitter_simple DesignReviewed 1085870671291310081 >}}
+{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/ru/posts/rich-content/index.md
+++ b/exampleSite/content/ru/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo поставляется с несколькими [встроенными 
 
 ## Простой шорт код для Twitter
 
-{{< twitter_simple DesignReviewed 1085870671291310081 >}}
+{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/layouts/partials/meta/post.html
+++ b/layouts/partials/meta/post.html
@@ -2,6 +2,7 @@
 {{ if eq .Section "posts" }}
     {{ $ISO_date := dateFormat "2006-01-02T15:04:05Z0700" .Date | safeHTML }}
     <!-- Pagination meta tags for list pages only -->
+    {{ if ne .Page.Kind "page" }}
     {{ $paginator := .Paginate (where .Pages "Section" "blog") }}
     {{ if $paginator }}
     <link rel="first" href="{{ $paginator.First.URL }}" />
@@ -11,6 +12,7 @@
     {{end }}
     {{ if $paginator.HasNext }}
     <link rel="next" href="{{ $paginator.Next.URL }}" />
+    {{end }}
     {{end }}
     {{end }}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.123.7"
   HUGO_THEME = "repo"
 
 # Deploy Preview context: all deploys generated from


### PR DESCRIPTION
## What problem does this PR solve?
Pages of kind "page" don't allow the creation of a paginator (.Paginate or .Paginator) in the newest version of hugo.
Pages of kind "section" (e.g. /posts) still allow the creation. This fix adds a check for the kind of page and excludes pages with kind "page" from creating a paginator.

## Is this PR adding a new feature?
No

## Is this PR related to any issue or discussion?
Closes #165 

## PR Checklist

- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [X] This change **does not** include any external library/resources.
- [X] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
