### PR TITLE
fix: RSS link on post pages, closes #160

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -310,4 +310,4 @@ url = "https://twitter.com"
 
 [[params.socialIcons]]
 name = "Rss"
-url = "index.xml"
+url = "/index.xml"


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Fixes broken RSS feed link on post pages.

## Is this PR adding a new feature?

No.

## Is this PR related to any issue or discussion?

#160 


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
