### PR TITLE
fix: Incorrect syntax for post image URL

### DIFF
--- a/layouts/partials/meta/post.html
+++ b/layouts/partials/meta/post.html
@@ -47,7 +47,7 @@
         "dateModified": "{{ dateFormat "2006-01-02" .Lastmod }}",
         "image": {
         "@type": "imageObject",
-        "url": "{{ with .Params.image }}{{ .Permalink }}{{ end }}"
+        "url": "{{ with .Params.image }}{{ . | absURL }}{{ end }}"
         },
         "publisher": {
         "@type": "Organization",


### PR DESCRIPTION
## What problem does this PR solve?

When an `image:` attribute is added to a page's frontmatter, it breaks site building because the template syntax used to convert it to an absolute URL is incorrect. This is a fix for that.

## Is this PR adding a new feature?

No

## Is this PR related to any issue or discussion?

No

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
