### PR TITLE
feat: Use site image in absence of page image

### DIFF
--- a/layouts/partials/meta/standard.html
+++ b/layouts/partials/meta/standard.html
@@ -31,14 +31,20 @@
   <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}" />
 {{ end }}
 
-{{ with .Params.image }}
-  <meta itemprop="image" content="{{ . | absURL }}" />
-  <meta property="og:image" content="{{ . | absURL }}" />
-  <meta name="twitter:image" content="{{ . | absURL }}" />
-  <meta name="twitter:image:src" content="{{ . | absURL }}" />
-{{ else }}
-  <meta itemprop="image" content="{{ .Site.Params.ogimage | absURL }}" />
-  <meta property="og:image" content="{{ .Site.Params.ogimage | absURL }}" />
-  <meta name="twitter:image" content="{{ .Site.Params.ogimage | absURL }}" />
-  <meta name="twitter:image:src" content="{{ .Site.Params.ogimage | absURL }}" />
-{{ end }}
+{{/*  Define empty variable image  */}}
+{{- $image := "" -}}
+
+{{/*  If image is defined in front matter, use it  */}}
+{{- if .Params.image -}}
+  {{- $image = .Params.image -}}
+{{/*  If image is not defined in front matter, use site ogimage  */}}
+{{- else if .Site.Params.ogimage -}}
+  {{- $image = .Site.Params.ogimage -}}
+{{- end -}}
+
+{{- if $image -}}
+<meta itemprop="image" content="{{ $image | absURL }}" />
+<meta property="og:image" content="{{ $image | absURL }}" />
+<meta name="twitter:image" content="{{ $image | absURL }}" />
+<meta name="twitter:image:src" content="{{ $image | absURL }}" />
+{{- end -}}


### PR DESCRIPTION
## What problem does this PR solve?

If a page doesn't include its own banner/open graph image, this causes a fall-back to the site-wide image, reasoning that showing *something* is better than nothing.

## Is this PR adding a new feature?

Yes; as above.

## Is this PR related to any issue or discussion?

No

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
