### PR TITLE
fix: Use author from site rather than post and don't humanize name

### DIFF
--- a/layouts/partials/meta/post.html
+++ b/layouts/partials/meta/post.html
@@ -20,10 +20,10 @@
     <meta property="og:article:published_time" content={{ $ISO_date | safeHTML }} />
     <meta property="article:published_time" content={{ $ISO_date | safeHTML }} />
 
-    {{ with.Params.author }}
-    <meta property="og:article:author" content="{{humanize . }}" />
-    <meta property="article:author" content="{{humanize . }}" />
-    <meta name="author" content="{{humanize . }}" />
+    {{ with.Site.Params.author }}
+    <meta property="og:article:author" content="{{ .name }}" />
+    <meta property="article:author" content="{{ .name }}" />
+    <meta name="author" content="{{ .name }}" />
     {{ end }}
 
     {{ with.Params.category }}


### PR DESCRIPTION
Running humanize on the name uses sentence case rather than title case, thus using lowercase for all words except the first. This way, the author can choose how they want their name to look.

## What problem does this PR solve?

1. Humanizing the author name is probably not the right behaviour since this will lowercase all but the first name.
2. This is the only reference I can see to an author *of a post* rather than of the site, so let's use the site author here too.

## Is this PR adding a new feature?

Sort of?

## Is this PR related to any issue or discussion?

No

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
