### PR TITLE
Add Social Previews

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,12 @@
     {{- partial "meta/main.html" . }}
     {{- hugo.Generator }}
 
+    {{/* Open Graph tags */}}
+    {{ template "_internal/opengraph.html" . }}
+
+    {{/* Twitter Card tags */}}
+    {{ template "_internal/twitter_cards.html" . }}
+
     {{/* Canonical link, RSS */}}
 
     <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
Add Hugo's built-in support for generating social previews when posting a link on social media sites. (Uses the open graph protocol).

<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?
Problem: Social media previews are missing when posting a link from the site to social media such as Facebook. 
Solution: This PR adds hugo's built-in open graph protocol script.
<!--
A small description of the fix.
-->

## Is this PR adding a new feature?
Yes
<!--
A small description of the feature.
-->

## Is this PR related to any issue or discussion?
https://github.com/hugo-sid/hugo-blog-awesome/discussions/215
<!--
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
