### PR TITLE
Feat: starr posts to get readers attention

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -3,5 +3,6 @@ title:
 date: {{ .Date }}
 draft: true
 description:
+isStarred: false
 ---
 

--- a/assets/sass/_listpage.scss
+++ b/assets/sass/_listpage.scss
@@ -1,3 +1,16 @@
 .list-page .post-year {
     padding-bottom: .5rem;
 }
+  
+.icon-star {
+  color: orange;
+  height: 16px;
+  margin-right: 1rem;
+  width: 16px;
+  display: block;
+}
+
+.post-item-right {
+  margin-left: auto;
+  margin-right: 0;
+}

--- a/exampleSite/content/en/posts/markdown-syntax/index.md
+++ b/exampleSite/content/en/posts/markdown-syntax/index.md
@@ -3,6 +3,7 @@ title: Markdown Syntax Guide
 date: 2023-02-11
 author: Hugo Authors
 description: Sample article showcasing basic Markdown syntax and formatting for HTML elements.
+isStarred: true
 ---
 
 This article offers a sample of basic Markdown syntax that can be used in Hugo content files, also it shows whether basic HTML elements are decorated with CSS in a Hugo theme.

--- a/layouts/partials/postCard.html
+++ b/layouts/partials/postCard.html
@@ -5,6 +5,11 @@
     {{/* format date string to create an ISO 8601 string */}}
     {{ $ISO_date := "2006-01-02T15:04:05Z0700" }}
     {{ $configDateFormat := .Site.Params.dateFormat | default "2 Jan 2006" }}
+    {{ if .Params.isStarred }}
+    <div class="post-item-right">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor" class="icon-star"><path d="M16 23.027L24.24 28l-2.187-9.373 7.28-6.307-9.587-.827-3.747-8.827-3.747 8.827-9.587.827 7.267 6.307L7.759 28l8.24-4.973z"></path></svg>
+    </div>
+    {{ end }}
     <time class="post-item-meta" datetime="{{ dateFormat $ISO_date .Date }}">
         {{ time.Format $configDateFormat .Date }}
         {{/* OLD FORMAT: .Date.Format $configDateFormat */}}


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->

## What problem does this PR solve?

None.

## Is this PR adding a new feature?

Indeed.
This PR will add the option to starr single posts. An author can set the optional config `isStarred: true` in a posts front matter. This will cause a little star icon to be rendered (for the post) in the list of posts.
An author can use this to get a readers attention.
The mentioned star will only be shown in the list of posts - nowhere else (to not overload the theme).

**For the records**
I set the `isStarred: true` in the front matter of the _Markdown Syntax Guide_ en-us example post to showcase this new option.
It might be worth recreating the themes demo picture (used here: https://themes.gohugo.io/themes/hugo-blog-awesome/) to attract the attention of possible theme users. 🤓 

## Is this PR related to any issue or discussion?

This feature was discussed here: https://github.com/hugo-sid/hugo-blog-awesome/discussions/222

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
