### PR TITLE
fix: Change line when inline code is long

### DIFF
--- a/assets/sass/_code.scss
+++ b/assets/sass/_code.scss
@@ -13,6 +13,7 @@ code {
 // Inline code
 li>code,
 p > code {
+  white-space: pre-wrap;
   font-size: 0.9em;
   padding: 1px 3px;
   position: relative;


### PR DESCRIPTION
## What problem does this PR solve?

Fixed 'Long inline code does not break line' bug
If the inline code was long, the code would be unreadable on a small screen like a phone. 

## Is this PR adding a new feature?

no

## Is this PR related to any issue or discussion?

Closes #133 


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
