### PR TITLE
fix: date on post is not following dateFormat 

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -90,7 +90,6 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
-  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .
@@ -155,7 +154,6 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "2 January 2006" # default date format used on various pages
-  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .
@@ -221,7 +219,6 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
-  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .
@@ -287,7 +284,6 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
-  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -90,6 +90,7 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
+  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .
@@ -154,6 +155,7 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "2 January 2006" # default date format used on various pages
+  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .
@@ -219,6 +221,7 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
+  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .
@@ -284,6 +287,7 @@ theme = "hugo-blog-awesome"
   # When building for production it will be minified.
   # The file `custom.js` is loaded on each page (before body tag ends).
   dateFormat = "" # date format used to show dates on various pages. If nothing is specified, then "2 Jan 2006" format is used.
+  postDateFormat = "" # date format used to show the published date at the beginning of each post. If nothing is specified, then ":date_medium" format is used.
   # See https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference for available date formats.
   rssFeedDescription = "summary" # available options: 1) summary 2) full
   # summary - includes a short summary of the blog post in the RSS feed. Generated using Hugo .Summary .

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
         <article>
             <header class="header">
                 <h1 class="header-title">{{ .Title }}</h1>
-                {{ $configDateFormat := .Site.Params.postDateFormat | default ":date_medium" }}
+                {{ $configDateFormat := .Site.Params.dateFormat | default ":date_medium" }}
                 {{ with .Date }}
                 {{ $ISO_time := dateFormat "2006-01-02T15:04:05-07:00" . }}
                 <div class="post-meta">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,10 +4,11 @@
         <article>
             <header class="header">
                 <h1 class="header-title">{{ .Title }}</h1>
+                {{ $configDateFormat := .Site.Params.postDateFormat | default ":date_medium" }}
                 {{ with .Date }}
                 {{ $ISO_time := dateFormat "2006-01-02T15:04:05-07:00" . }}
                 <div class="post-meta">
-                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ . | time.Format ":date_medium" }} </time>
+                    <time datetime="{{ $ISO_time }}" itemprop="datePublished"> {{ . | time.Format $configDateFormat }} </time>
                 </div>
                 {{ end }}
             </header>


### PR DESCRIPTION
Add extra option to change the date format
displayed at the beginning of the single.html

<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

The date format at the beginning of post did not follow the `dateFormat`
config option.
<!--
A small description of the fix.
-->

## Is this PR adding a new feature?

<!--
A small description of the feature.
-->
I added an extra option `postDateFormat` to set the date format at the beginning of a post.
I added this option because I like the idea of being able to display the date
more verbose at the start of the post. (Moreover this makes it possible
to add this in a backwards compatible manner, by not changing the current
behavior if the `postDateFormat` option is not defined)

## Is this PR related to any issue or discussion?

<!--
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->
See #177


## PR Checklist

- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [X] This change **does not** include any external library/resources.
- [X] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
