### PR TITLE
feat: support user-supplied <head> html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<div align=center> 
+<div align=center>
  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/hugo-sid/hugo-blog-awesome/main/assets/icons/book-icon-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/hugo-sid/hugo-blog-awesome/main/assets/icons/book-icon-light.svg">
   <img alt="Hugo blog awesome logo" src="https://raw.githubusercontent.com/hugo-sid/hugo-blog-awesome/feat/logo-change/assets/icons/book-icon-light.svg" />
 </picture>
- 
+
 </div>
 <h1 align=center> Hugo Blog Awesome | <a href="https://hba.sid.one" target="_blank" rel="nofollow">Demo link</a></h1>
 
@@ -219,6 +219,11 @@ To enable go to top button on blog posts, set `goToTop` to `true` in `hugo.toml`
 [params]
   goToTop = true
 ```
+
+### Add custom HTML to `<head>` section
+
+To add custom HTML to the `<head>` section, create a partial named `custom-head.html`.
+The contents of this partial will be inserted at the end of the `<head>` section.
 
 ## Content
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,4 +47,8 @@
     {{ template "_internal/google_analytics.html" . }}
     {{- end -}}
 
+    {{/* Extend head with user supplied partial */}}
+    {{ if templates.Exists "partials/custom-head.html" }}
+      {{ partial "custom-head.html" . }}
+    {{ end }}
 </head>


### PR DESCRIPTION
If theme user creates a "custom-head.html" partial, it will be included at the end of the <head> section.

Related discussion: https://github.com/hugo-sid/hugo-blog-awesome/discussions/152

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
