### PR TITLE
fix: off-centre author avatars

### DIFF
--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -8,10 +8,10 @@
         <image width="25em" height="25em" href="{{ $image.RelPermalink }}" />
     </svg>
     {{ else }}
-    {{ $image1x := $image.Fill "70x70 webp" }}
-    {{ $image2x := $image.Fill "140x140 webp" }}
-    {{ $image3x := $image.Fill "210x210 webp" }}
-    <img 
+    {{ $image1x := $image.Fill "70x70 center webp" }}
+    {{ $image2x := $image.Fill "140x140 center webp" }}
+    {{ $image3x := $image.Fill "210x210 center webp" }}
+    <img
         class="author-avatar"
         src="{{ $image1x.RelPermalink }}"
         srcset="{{ $image2x.RelPermalink }} 2x, {{ $image3x.RelPermalink }} 3x"


### PR DESCRIPTION
## What problem does this PR solve?

Avatar images are currently cropped using `smart` mode, which in my experience leads to the avatar appearing off-centre. Changing to `center` fixes this.

## Is this PR adding a new feature?

No.

## Is this PR related to any issue or discussion?

No. 

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
