### PR TITLE
fix: align author image display size & actual size

### DIFF
--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -9,8 +9,8 @@
     </svg>
     {{ else }}
     {{ $image := $image.Fill "70x70 webp" }}
-    <img class="author-avatar" src="{{ $image.RelPermalink }}" alt="{{ $avatar_img_alt }}" width="{{ .Width }}"
-        height="{{ .Height }}" />
+    <img class="author-avatar" src="{{ $image.RelPermalink }}" alt="{{ $avatar_img_alt }}" width="{{ $image.Width }}"
+        height="{{ $image.Height }}" />
     {{ end }}
     {{ end }}
     <h2 class="author-name">{{ .Site.Params.author.intro }}</h2>

--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -8,9 +8,16 @@
         <image width="25em" height="25em" href="{{ $image.RelPermalink }}" />
     </svg>
     {{ else }}
-    {{ $image := $image.Fill "70x70 webp" }}
-    <img class="author-avatar" src="{{ $image.RelPermalink }}" alt="{{ $avatar_img_alt }}" width="{{ $image.Width }}"
-        height="{{ $image.Height }}" />
+    {{ $image1x := $image.Fill "70x70 webp" }}
+    {{ $image2x := $image.Fill "140x140 webp" }}
+    {{ $image3x := $image.Fill "210x210 webp" }}
+    <img 
+        class="author-avatar"
+        src="{{ $image1x.RelPermalink }}"
+        srcset="{{ $image2x.RelPermalink }} 2x, {{ $image3x.RelPermalink }} 3x"
+        alt="{{ $avatar_img_alt }}"
+        width="{{ $image1x.Width }}"
+        height="{{ $image1x.Height }}" />
     {{ end }}
     {{ end }}
     <h2 class="author-name">{{ .Site.Params.author.intro }}</h2>

--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -8,7 +8,7 @@
         <image width="25em" height="25em" href="{{ $image.RelPermalink }}" />
     </svg>
     {{ else }}
-    {{ $image := $image.Fill "100x100 webp" }}
+    {{ $image := $image.Fill "70x70 webp" }}
     <img class="author-avatar" src="{{ $image.RelPermalink }}" alt="{{ $avatar_img_alt }}" width="{{ .Width }}"
         height="{{ .Height }}" />
     {{ end }}


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Cleanup author image handling and use `<img />` `scrset` attribute to better expose display density-compliant images. Being the only image really showed in the entire theme, it deserves polish.

## Is this PR adding a new feature?

No

## Is this PR related to any issue or discussion?

No

## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
