### PR TITLE
fix: replace removed hugo methods

### DIFF
--- a/exampleSite/content/br/posts/rich-content/index.md
+++ b/exampleSite/content/br/posts/rich-content/index.md
@@ -19,7 +19,7 @@ O Hugo vem com vários [Shortcodes Integrados](https://gohugo.io/content-managem
 
 ## Shortcode Simples do Twitter
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/de/posts/rich-content/index.md
+++ b/exampleSite/content/de/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/en/posts/rich-content/index.md
+++ b/exampleSite/content/en/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/fr/posts/rich-content/index.md
+++ b/exampleSite/content/fr/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo est livré avec plusieurs Shortcodes intégrés pour le contenu riche, ains
 
 ## Simple Shortcode pour Twitter
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/it/posts/rich-content/index.md
+++ b/exampleSite/content/it/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo viene distribuito con alcuni [Shortcode integrati](https://gohugo.io/conten
 
 ## Semplice Shortcode Per Twitter
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/ja/posts/rich-content/index.md
+++ b/exampleSite/content/ja/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugoはリッチコンテンツにご利用いただける多くの[標準ショ
 
 ## Twitter シンプルショートコード
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/ru/posts/rich-content/index.md
+++ b/exampleSite/content/ru/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo поставляется с несколькими [встроенными 
 
 ## Простой шорт код для Twitter
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSite/content/zh/posts/rich-content/index.md
+++ b/exampleSite/content/zh/posts/rich-content/index.md
@@ -19,7 +19,7 @@ Hugo 提供了多个[内置短代码](https://gohugo.io/content-management/short
 
 ## Twitter 简单短代码
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -19,9 +19,9 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>{{ site.Language.LanguageCode }}</language>{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{ site.Language.LanguageCode }}</language>{{ with site.Params.Author.email }}
+    <managingEditor>{{.}}{{ with site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with site.Params.Author.email }}
+    <webMaster>{{.}}{{ with site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with site.Params.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -32,7 +32,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with site.Params.Author.email }}<author>{{.}}{{ with site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       {{ if eq $rssFeedDescription "summary"}}
       <description>{{ .Summary | html }}</description>

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,9 +7,9 @@
   command = "cd exampleSite && hugo --gc --themesDir ../.."
 
 [build.environment]
-  HUGO_VERSION = "0.123.8"
-  GO_VERSION = "1.22.1"
-  NODE_VERSION = "20"
+  HUGO_VERSION = "0.162.1"
+  GO_VERSION = "1.26.3"
+  NODE_VERSION = "22"
   HUGO_THEME = "repo"
 
 # Deploy Preview context: all deploys generated from


### PR DESCRIPTION
## What problem does this PR solve?

Fix issue #343.
After hugo 0.156.0 update, some deprecated methods were removed which cause build failure.

The fix replace removed methods with new ones.


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
