### PR TITLE
Fix JSON-LD templating

### DIFF
--- a/layouts/partials/meta/post.html
+++ b/layouts/partials/meta/post.html
@@ -35,27 +35,27 @@
     <meta property="article:section" content="{{ index . 0 }}" />
     {{ end }}
 
-    <script defer type="application/ld+json">
+    <script type="application/ld+json">
     {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": "Article",
         "headline": {{ .Title }},
         "author": {
         "@type": "Person",
-        "name": "{{ .Site.Params.github }}"
+        "name": "{{ with .Site.Params.author }}{{ .name }}{{ end }}"
         },
-        "datePublished": "{{ dateFormat "2006-01-02" .Date }}",
+        "datePublished": {{ dateFormat "2006-01-02" .Date }},
         "description": {{ .Description }},
         "wordCount": {{ .WordCount }},
-        "mainEntityOfPage": "True",
-        "dateModified": "{{ dateFormat "2006-01-02" .Lastmod }}",
+        "mainEntityOfPage": {{ .Permalink }},
+        "dateModified": {{ dateFormat "2006-01-02" .Lastmod }},
         "image": {
-        "@type": "imageObject",
-        "url": "{{ with .Params.image }}{{ . | absURL }}{{ end }}"
+        "@type": "ImageObject",
+        "url": {{ with .Params.images }}{{ index . 0 | absURL }}{{ else }}""{{ end }}
         },
         "publisher": {
         "@type": "Organization",
-        "name": "{{ .Site.Title }}"
+        "name": {{ .Site.Title }}
         }
     }
     </script>


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

This solves Issue #352

<!--
A small description of the fix.
-->

## Is this PR adding a new feature?

<!--
A small description of the feature.
-->
No, this PR fixes missing values in the JSON-LD of posts. It also cleans up the current template in line with best practices with the following changes:
1. `https://schema.org` instead of `http://schema.org` for the `@context` field
2. Removes `defer` from the `script` tag since the content is data, not a script
3. `mainEntityOfPage` points to a permalink of the page, instead of `"True"`

Here's an example of the output without this fix applied:
```html
    <script defer type="application/ld+json">
     {
         "@context": "http://schema.org",
         "@type": "Article",
         "headline": "Sakamata's absence looms high over holoX's First Mission",
         "author": {
         "@type": "Person",
         "name": ""
         },
         "datePublished": "2026-05-04",
         "description": "HoloX's active members look to the future while embracing the past.",
         "wordCount":  1834 ,
         "mainEntityOfPage": "True",
         "dateModified": "2026-05-04",
         "image": {
         "@type": "imageObject",
         "url": ""
         },
         "publisher": {
         "@type": "Organization",
         "name": "sg4e\u0027s blog"
         }
     }
     </script>
```
And here's what it looks like after applying this fix:
```html
    <script type="application/ld+json">
    {
        "@context": "https://schema.org",
        "@type": "Article",
        "headline": "Sakamata's absence looms high over holoX's First Mission",
        "author": {
        "@type": "Person",
        "name": "sg4e"
        },
        "datePublished": "2026-05-04",
        "description": "HoloX's active members look to the future while embracing the past.",
        "wordCount":  1834 ,
        "mainEntityOfPage": "https://maika.moe/blog/posts/holox-first-mission/",
        "dateModified": "2026-05-04",
        "image": {
        "@type": "ImageObject",
        "url": "https://maika.moe/blog/covers/chronicle.jpg"
        },
        "publisher": {
        "@type": "Organization",
        "name": "sg4e's blog"
        }
    }
    </script>
```
## Is this PR related to any issue or discussion?
Issue #352
<!--
Provide link(s) to any relevant issue or discussion post here.

If this PR resolves an existing issue (say issue number 1), write "Closes #1" in your pull request description (not in title) so that the issue is closed automatically when this PR is merged.
-->


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
