### PR TITLE
fix: use release please config file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,4 @@
           with:
             release-type: simple
             token: ${{ secrets.HBA_RELEASE_PLEASE_TOKEN }}
-            pull-request-header: ":rocket: New release"
-            changelog-types: '[{"type":"feat","section":":sparkles: Features","hidden":false},{"type":"fix","section":":bug: Bug Fixes","hidden":false},{"type":"chore","section":":hammer: Housekeeping","hidden":false},{"type":"docs","section":":memo: Documentation","hidden":false},{"type":"ci","section":":construction_worker: CI/CD","hidden":false},{"type":"perf","section":":zap: Performance","hidden":false},{"type":"refactor","section":":recycle: Refactoring","hidden":false},{"type":"style","section":":art: Style","hidden":false},{"type":"test","section":":white_check_mark: Tests","hidden":false}]'
+            config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,43 @@
+{
+  "release-type": "simple",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": ":sparkles: Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": ":bug: Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": ":hammer: Housekeeping",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": ":memo: Documentation",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": ":construction_worker: CI/CD",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": ":recycle: Refactoring",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": ":white_check_mark: Tests",
+      "hidden": false
+    }
+  ],
+  "packages": {
+    ".": {}
+  }
+}


### PR DESCRIPTION
<!--

## Read this before opening a PR.

Thank you for contributing to hugo-blog-awesome!
Please fill out the following questions to make it easier for us to review your
changes. Neither you need to answer all questions nor you have to check all the boxes below.

-->


## What problem does this PR solve?

Adds a new release please config file which is supported by googleapis/release-please-action v5.0.0

## Is this PR adding a new feature?

No

## Is this PR related to any issue or discussion?

No


## PR Checklist

- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a social icon which has a permissive license to use it.
- [x] This change **does not** include any external library/resources.
- [x] This change **does not** include any unrelated scripts (e.g. bash and python scripts).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
